### PR TITLE
10x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,24 @@ OBJS = $(foreach dir,$(SRC_DIR),$(subst .c,.o,$(wildcard $(dir)/*.c))) $(foreach
 OUTPUT = mooooooo
 CXXFLAGS = -Wall -g -I. -Iunicorn/include -std=c++17
 CFLAGS = -I. -Iunicorn/include -std=gnu11
-LIBS = -lpthread unicorn/libunicorn.a -lstdc++fs
+LIBS = -pthread unicorn/libunicorn.a -lstdc++fs
 CC = gcc
 CXX = g++
 ifeq ($(OS),Windows_NT)
     #Windows Build CFG
-    CFLAGS += 
-    LIBS += 
+    CFLAGS +=
+    LIBS +=
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Darwin)
         # OS X
         CFLAGS +=
-        LIBS += 
+        LIBS +=
     else
         # Linux
-        CFLAGS += 
-        CXXFLAGS += 
-        LIBS += 
+        CFLAGS +=
+        CXXFLAGS +=
+        LIBS +=
     endif
 endif
 


### PR DESCRIPTION
This adds support for booting newer kernels which actually use the argument to smc cpu on.

It also adds some logic that greatly improves runtime speed on newer kernels, by stopping slice emulation and moving on to the next core when WFE is executed.